### PR TITLE
chore: Update intl package version to ^0.20.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  intl: ^0.18.0
+  intl: ^0.20.2
   collection: ^1.17.0
 
 dev_dependencies:


### PR DESCRIPTION
This pull request updates the version of the `intl` package in the `pubspec.yaml` dependencies to ensure compatibility with the latest features and bug fixes.

* Dependency update:
  * Upgraded `intl` from version `^0.18.0` to `^0.20.2` in `pubspec.yaml` to use the most recent release.